### PR TITLE
feat: Add TTP Provider

### DIFF
--- a/examples/ttp-test/README.md
+++ b/examples/ttp-test/README.md
@@ -1,0 +1,28 @@
+# Test For Trust Third Party Provider
+
+## run
+
+```shell
+python3 run_test_ttp.py
+```
+
+```shell
+python3 run_test_bert.py
+```
+
+## use
+
+specify in the code
+
+```shell
+import crypten
+
+crypten.cfg.mpc.provider = "TTP"
+```
+
+or edit the configs/default.yaml
+
+```yaml
+mpc:
+  provider: "TTP" # default is TFP
+```

--- a/examples/ttp-test/run_test_bert.py
+++ b/examples/ttp-test/run_test_bert.py
@@ -1,0 +1,92 @@
+import crypten
+import torch
+from transformers import BertForSequenceClassification, BertConfig
+
+crypten.cfg.debug.report_cost = True
+
+
+class BertTinyConfig(BertConfig):
+    def __init__(self):
+        super().__init__(
+            vocab_size=30522,
+            hidden_size=128,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            intermediate_size=512,
+            max_position_embeddings=512,
+            type_vocab_size=2,
+            layer_norm_eps=1e-12,
+            pad_token_id=0,
+            num_labels=2
+        )
+
+
+class BertBaseConfig(BertConfig):
+    def __init__(self):
+        super().__init__()
+
+
+class BertLargeConfig(BertConfig):
+    def __init__(self):
+        super().__init__(
+            vocab_size=30522,
+            hidden_size=1024,
+            num_hidden_layers=24,
+            num_attention_heads=16,
+            intermediate_size=4096,
+            max_position_embeddings=512,
+            type_vocab_size=2,
+            layer_norm_eps=1e-12,
+            pad_token_id=0,
+            num_labels=2
+        )
+
+
+@crypten.mpc.context.run_multiprocess(2)
+def test_bert(config: BertConfig = BertTinyConfig(), input_shape: tuple = (1, 128), device: str = "cuda"):
+    crypten.init()
+
+    print(config.__class__.__name__)
+    model = BertForSequenceClassification(config)
+    model = model.to(device)
+    model = model.eval()
+    # BertTiny:
+    #   TTP: comm byte: 0.48 GB, round: 1180
+    #   TFP: comm byte: 0.37 GB, round: 296
+    # BertBase:
+    #   TTP: comm byte: 13.41 GB, round: 5980
+    #   TFP: comm byte: 10.48 GB, round: 1496
+    # BertLarge:
+    #   TFP: comm byte: 28.49 GB, round: 2936
+    #   TTP: comm byte: 36.26 GB, round: 11744
+    ct_model = crypten.nn.from_pytorch(model, (
+        torch.zeros(input_shape, dtype=torch.int64).to(device),
+        torch.zeros(input_shape, dtype=torch.int64).to(device),
+        torch.zeros(input_shape, dtype=torch.int64).to(device),
+    )).encrypt()
+    with torch.no_grad():
+        print(f"[rank {crypten.communicator.get().rank}]", "input shape: ", input_shape)
+        ct_input_ids = crypten.cryptensor(torch.zeros(input_shape, dtype=torch.int64).to(device))
+        ct_attention_mask = crypten.cryptensor(torch.zeros(input_shape, dtype=torch.int64).to(device))
+        ct_token_type_ids = crypten.cryptensor(torch.zeros(input_shape, dtype=torch.int64).to(device))
+
+        get_v = ct_model(ct_input_ids, ct_attention_mask, ct_token_type_ids)
+
+        get_v = get_v.get_plain_text()
+        need_v = model.forward(torch.zeros(input_shape, dtype=torch.int64).to(device),
+                               torch.zeros(input_shape, dtype=torch.int64).to(device),
+                               torch.zeros(input_shape, dtype=torch.int64).to(device),
+                               )
+        print("ct model results", get_v)
+        print("pt model results", need_v)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(101)
+    torch.random.manual_seed(101)
+    torch.cuda.manual_seed(101)
+    torch.cuda.random.manual_seed(101)
+    crypten.cfg.mpc.provider = "TTP"
+    test_bert(BertTinyConfig(), (1, 128), "cuda")
+    test_bert(BertBaseConfig(), (1, 128), "cuda")
+    test_bert(BertLargeConfig(), (1, 128), "cuda")

--- a/examples/ttp-test/run_test_ttp.py
+++ b/examples/ttp-test/run_test_ttp.py
@@ -1,0 +1,122 @@
+import time
+import torch
+import crypten
+
+crypten.cfg.communicator.verbose = True
+
+
+def test_gelu(runs: int = 10, device: str = "cpu"):
+    gelu_approximate = "none"
+
+    x = torch.arange(-5, 5, 0.001)
+    y_original = torch.nn.functional.gelu(x, approximate=gelu_approximate)
+    y_actual = crypten.cryptensor(x).gelu(approximate=gelu_approximate).get_plain_text()
+    max_err = (y_original - y_actual).abs().max()
+    min_err = (y_original - y_actual).abs().min()
+    avg_err = (y_original - y_actual).abs().mean()
+
+    size = (128, 3072)
+    x = crypten.cryptensor(torch.zeros(size), device=device)
+    crypten.reset_communication_stats()
+    start_time = time.time()
+
+    for _ in range(runs):
+        x.gelu(approximate=gelu_approximate)
+    comm_time = time.time() - start_time
+    stats = crypten.get_communication_stats()
+    comm_bytes = stats["bytes"]
+    comm_rounds = stats["rounds"]
+
+    log = f"gelu: max error: {max_err}, avg error: {avg_err}, min error: {min_err} "
+    log += f"{size} time: {comm_time / runs}s, bytes: {comm_bytes / (2 ** 20) / runs} MB, rounds: {comm_rounds / runs}"
+    log = f"[rank {crypten.comm.get().get_rank()}] [provider {crypten.cfg.mpc.provider}] " + log
+    print(log)
+
+
+def test_softmax(runs: int = 10, device: str = "cpu"):
+    x = torch.arange(-5, 5, 0.001)
+    y_original = torch.nn.functional.softmax(x, -1)
+    y_actual = crypten.cryptensor(x).softmax(-1).get_plain_text()
+    max_err = (y_original - y_actual).abs().max()
+    avg_err = (y_original - y_actual).abs().mean()
+    min_err = (y_original - y_actual).abs().min()
+
+    size = (12, 128, 128)
+    x = crypten.cryptensor(torch.zeros(size), device=device)
+    crypten.reset_communication_stats()
+    start_time = time.time()
+
+    for _ in range(runs):
+        y = x.softmax(-1)
+    comm_time = time.time() - start_time
+    stats = crypten.get_communication_stats()
+    comm_bytes = stats["bytes"]
+    comm_rounds = stats["rounds"]
+
+    log = f"softmax: max error: {max_err}, avg error: {avg_err}, min error: {min_err} "
+    log += f"{size} time: {comm_time / runs}s, bytes: {comm_bytes / (2 ** 20) / runs} MB, rounds: {comm_rounds / runs}"
+    log = f"[rank {crypten.comm.get().get_rank()}] [provider {crypten.cfg.mpc.provider}] " + log
+    print(log)
+
+
+def test_embedding(runs: int = 10, device: str = "cuda"):
+    num_embeddings = 32
+    embedding_dim = 768
+
+    ct_emb = crypten.nn.module.Embedding().to(device)
+    pt_emb = torch.nn.Embedding(num_embeddings, embedding_dim, device=device)
+    pt_x = torch.randint(0, num_embeddings, (1, 128), device=device)
+    y_original = pt_emb.forward(pt_x)
+    y_actual = ct_emb.forward(
+        (crypten.cryptensor(pt_emb.weight), crypten.cryptensor(pt_x), None)
+    ).get_plain_text()
+    max_err = (y_original - y_actual).abs().max()
+    avg_err = (y_original - y_actual).abs().mean()
+    min_err = (y_original - y_actual).abs().min()
+    print(f"[rank {crypten.comm.get().get_rank()}] [provider {crypten.cfg.mpc.provider}] "
+          f"Embedding max error: {max_err:.4f}, avg error: {avg_err:.6f}, min error: {min_err:.6f}")
+    embedding_time = {}
+    embedding_bytes = {}
+    embedding_rounds = {}
+
+    embedding_sizes = [(1, 128), (1, 256)]
+    pt_emb = torch.nn.Embedding(num_embeddings, embedding_dim).to(device)
+    for embedding_size in embedding_sizes:
+        embedding_in = crypten.cryptensor(torch.randint(0, num_embeddings, embedding_size), device=device)
+        crypten.reset_communication_stats()
+        start_time = time.time()
+
+        for _ in range(runs):
+            ct_emb.forward(
+                (crypten.cryptensor(pt_emb.weight), embedding_in, None)
+            )
+        embedding_time[embedding_size[1]] = time.time() - start_time
+        stats = crypten.get_communication_stats()
+        embedding_bytes[embedding_size[1]] = stats["bytes"]
+        embedding_rounds[embedding_size[1]] = stats["rounds"]
+
+    for embedding_size in embedding_sizes:
+        print(f"[rank {crypten.comm.get().get_rank()}] [provider {crypten.cfg.mpc.provider}] "
+              f"Embedding ({embedding_size[0]}, {embedding_size[1]}) "
+              f"time: {embedding_time[embedding_size[1]] / runs:.4f}s, "
+              f"bytes: {embedding_bytes[embedding_size[1]] / 2 ** 20 / runs:.0f} MB, "
+              f"rounds: {embedding_rounds[embedding_size[1]] / runs:.0f}"
+              )
+
+
+@crypten.mpc.context.run_multiprocess(2)
+def main(device: str = "cuda"):
+    test_gelu(device=device)
+    test_softmax(device=device)
+    test_embedding(device=device)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(101)
+    torch.random.manual_seed(101)
+    torch.cuda.manual_seed(101)
+    torch.cuda.random.manual_seed(101)
+    crypten.cfg.mpc.provider = "TTP"
+    main()
+    crypten.cfg.mpc.provider = "TFP"
+    main()


### PR DESCRIPTION
## Description

Add TTP Provider

## Type of Change

New feature

## Implementation Details

- implement the `generate_trig_triple` and `generate_one_hot_pair` functions in `crypten/mpc/provider/ttp_provider` 

## Testing Performed

- add TTP test file `examples/ttp-test/*`